### PR TITLE
Small fix for save_records

### DIFF
--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -992,10 +992,7 @@ class Query:
             self.con.commit()
 
             # Lets refresh our data
-            pk = self.get_current_pk()
-            self.requery(update_elements)
-            self.set_by_pk(pk,update_elements,False,skip_prompt_save=True)
-            #self.requery_dependents()
+            self.requery(select_first=False) # don't move or update any elements
             if update_elements:self.frm.update_elements(self.table)
             logger.debug(f'Record Saved!')
             if display_message:  sg.popup_quick_message('Updates saved successfully!',keep_on_top=True)


### PR DESCRIPTION
self.requery(update_elements)

update_elements = True

but requery's first arg is select_first. So this was calling first(), that then called update_elements on the entire form - deleting unsaved changes on other unrelated tables