### PR TITLE
Explicitly close database

### DIFF
--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -1391,6 +1391,9 @@ class Form:
             self.bind(self.window)
 
     def __del__(self):
+        self.close()
+
+    def db_close(self):
         # Only do cleanup if this is not an imported database
         if not self.imported_database:
             # optimize the database for long-term benefits
@@ -1408,6 +1411,7 @@ class Form:
         # Safely close out the form
         # First delete the queries associated
         Query.purge_form(self,reset_keygen)
+        self.db_close()
 
     def bind(self, win):
         """


### PR DESCRIPTION
On my system, the -wal -shm files were being left open.

I did some reading, and people say that __del__ can't be completely relied on to ever be called.

Sure enough, if I put a print() in there, it wasn't. Even if I did `del frm`. Not sure why... right now I'm running from Thonny (python 3.10.6).

So I changed the __del__ to db_close, and, added it to close(), and will be replacing:

`frm = None' with `frm.close()`

Let me know, and I can also change the examples