### PR TITLE
Use table_name if available on first for-loop of update_elements

### DIFF
--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -1931,6 +1931,8 @@ class Form:
         win = self.window
         # Disable/Enable action elements based on edit_protect or other situations
         for t in self.queries:
+            if table_name and t != table_name:
+                continue
             # hide mapped elements for this table if there are no records in this table or edit protect mode
             hide = len(self[t].rows) == 0 or self._edit_protect
             self.update_element_states(t, hide)


### PR DESCRIPTION
Here was a really easy win 😄 I didn't see any changed behavior with this.

I timed 50 iterations of switching between two parent records on my parent/child/grandparent form:

```
        frm['person'].set_by_pk(2)
        frm['person'].set_by_pk(1)
```

Before - 43 seconds
After - 26 seconds.