### PR TITLE
Example selector cache using tables

### DIFF
--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -2165,11 +2165,11 @@ class Form:
                         except ValueError:
                             index = []
                         logger.debug(f'Selector:: index:{index} found:{found}')
-                        if element in table.element_cache.keys():
-                            if table.element_cache[element] != [values,index]:
+                        if element.key in table.element_cache.keys():
+                            if table.element_cache[element.key] != [values,index]:
                                 element.update(values=values,select_rows=index)
                         else: element.update(values=values,select_rows=index) # first time this selector won't be in the cache                          
-                        table.element_cache[element] = [values,index] # fastest when here and not under element.update()
+                        table.element_cache[element.key] = [values,index] # update cache
                         # set vertical scroll bar to follow selected element
                         if len(index): element.set_vscroll_position(pk_position)
                         eat_events(self.window)

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -265,6 +265,7 @@ class Query:
         self.rows = []
         self.search_order = []
         self.selector = []
+        self.element_cache = {}
         self.callbacks = {}
         self.transform = None
         self.filtered = filtered
@@ -2071,7 +2072,7 @@ class Form:
 
                 d['element'].update(values=values, select_rows=index)
 
-                # set virtical scroll bar to follow selected element
+                # set vertical scroll bar to follow selected element
                 if len(index): d['element'].set_vscroll_position(pk_position)
 
                 eat_events(self.window)
@@ -2164,8 +2165,13 @@ class Form:
                         except ValueError:
                             index = []
                         logger.debug(f'Selector:: index:{index} found:{found}')
-                        element.update(values=values,select_rows=index)
-                        # set virtical scroll bar to follow selected element
+                        try:
+                            if table.element_cache[element] != [values,index]:
+                                element.update(values=values,select_rows=index)
+                        except KeyError: # first time this selector won't be in the cache
+                            element.update(values=values,select_rows=index)
+                        table.element_cache[element] = [values,index]
+                        # set vertical scroll bar to follow selected element
                         if len(index): element.set_vscroll_position(pk_position)
                         eat_events(self.window)
 

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -2165,12 +2165,11 @@ class Form:
                         except ValueError:
                             index = []
                         logger.debug(f'Selector:: index:{index} found:{found}')
-                        try:
+                        if element in table.element_cache.keys():
                             if table.element_cache[element] != [values,index]:
                                 element.update(values=values,select_rows=index)
-                        except KeyError: # first time this selector won't be in the cache
-                            element.update(values=values,select_rows=index)
-                        table.element_cache[element] = [values,index] # fastest when here and not at bottom of try block
+                        else: element.update(values=values,select_rows=index) # first time this selector won't be in the cache                          
+                        table.element_cache[element] = [values,index] # fastest when here and not under element.update()
                         # set vertical scroll bar to follow selected element
                         if len(index): element.set_vscroll_position(pk_position)
                         eat_events(self.window)

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -2170,7 +2170,7 @@ class Form:
                                 element.update(values=values,select_rows=index)
                         except KeyError: # first time this selector won't be in the cache
                             element.update(values=values,select_rows=index)
-                        table.element_cache[element] = [values,index]
+                        table.element_cache[element] = [values,index] # fastest when here and not at bottom of try block
                         # set vertical scroll bar to follow selected element
                         if len(index): element.set_vscroll_position(pk_position)
                         eat_events(self.window)


### PR DESCRIPTION
Here is a simple element cache for just selector tables. Using my parent/child/grandchild example.

Each person parent pk switch can update 4 selector tables.

From Pk 1 to Pk 2, The Bike/Bike Repair, and Car tables were repopulated.

50 iterations
Old - ~29 seconds
New - 16 seconds.