### PR TITLE
Possible fix for _TIMEOUT_ on each Heading Sort

### DIFF
--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -124,7 +124,7 @@ def eat_events(win:sg.Window) -> None:
     :returns: None
     """
     while True:
-        event,values=win.read(timeout=0)
+        event,values=win.read(timeout=1)
         if event=='__TIMEOUT__':
             break
     return


### PR DESCRIPTION
This fixed it from emitting `_TIMEOUT_` on each heading sort. Give it a try.