### PR TITLE
Add 'load' to themepack and languagepack

### DIFF
--- a/examples/Flatfile_examples/csv_test.py
+++ b/examples/Flatfile_examples/csv_test.py
@@ -4,6 +4,9 @@ import logging
 logger=logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
+# Let's use a fun language pack
+ss.lang.load(ss.lp['monty_python'])
+
 # Create a simple layout for working with our flatfile data.
 # Note that you can set a specific table name to use, but here I am just using the defaul 'Flatfile'
 # Lets also use some sortable headers so that we can rearrange the flatfile data when saving
@@ -39,9 +42,6 @@ frm.set_force_save(True)
 
 # Make it so that the name, address and email can be part of the search
 frm['Flatfile'].set_search_order(['name', 'address', 'email'])
-
-# Let's use a fun language pack
-ss.language_pack = ss.lp_90s
 
 # As you can see, using a Flatfile is just like using any database with pysimplesql!
 while True:

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -3594,6 +3594,9 @@ class ThemePack:
                 return ThemePack.default[key]
             except KeyError:
                 raise AttributeError(f"ThemePack object has no attribute '{key}'")
+            
+    def load(self, key):
+        self.tp_dict = key
 
 
 
@@ -3719,6 +3722,9 @@ class LanguagePack:
                 return type(self).default[key]
             except KeyError:
                 raise AttributeError(f"LanguagePack object has no attribute '{key}'")
+            
+    def load(self, key):
+        self.lp_dict = key
 
 # set a default languagepack
 lang = LanguagePack()
@@ -4157,7 +4163,6 @@ class ResultSet:
 
     def __setitem__(self, idx:int, new_row:ResultRow):
         # carry over the original_index
-        new_row.original_index = self.rows[idx].original_index
         try:
             new_row.original_index = self.rows[idx].original_index
         except AttributeError:


### PR DESCRIPTION
Doesn't work without it. Do you want to rename themepack (`themepack = ThemePack()` in the code) to theme?

now you call at top of file like:
```
ss.lang.load(ss.lp['monty_python'])
ss.themepack.load(ss.tp_large)
```

Before 3.0 we can finalize what fun language packs you want.
I had to start splitting the dict into 2, or it wouldn't finish.
To get it to be even more crazy, you just put 'super' in front of fun.
So second half of the monty python I did:
`Can you look at this dict and make a super fun monty python version?`