### PR TITLE
Have progressbar use ttk_theme

### DIFF
--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -2900,7 +2900,7 @@ class ProgressBar:
 
         self.title = title
         self.max = max
-        self.win = sg.Window(title, layout=layout, keep_on_top=True, finalize=True)
+        self.win = sg.Window(title, layout=layout, keep_on_top=True, finalize=True, ttk_theme=themepack.ttk_theme)
 
     def update(self, message: str, current_count: int):
         self.win['message'].update(message)


### PR DESCRIPTION
Fixed this on the quick-editor awhile back. Otherwise on first event the whole window updates to the theme set by the user.