### PR TITLE
Recursive delete implemented as “delete from table where pk_column in (…inner joins)

### DIFF
--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -4629,7 +4629,7 @@ class SQLDriver:
                 return DELETE_RECURSION_LIMIT_ERROR
             
             # Create query and execute
-            q = delete_clause + "(" + select_clause + inner_join_clause + where_clause + ")"
+            q = delete_clause + "(" + select_clause + inner_join_clause + where_clause + ");"
             self.execute(q)
             logger.debug(f'Delete query executed: {q}')
 

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -4610,8 +4610,8 @@ class SQLDriver:
                 return DELETE_RECURSION_LIMIT_ERROR
 
             # Get data for query
-            fk_column = self.quote_column(Relationship.get_cascade_fk_column(child, dataset.frm)) # Toggle this if you merge before the Relationship Redo
-#             fk_column = self.quote_column(Relationship.get_cascade_fk_column(child)) # Toggle
+#             fk_column = self.quote_column(Relationship.get_cascade_fk_column(child, dataset.frm)) # Toggle this if you merge before the Relationship Redo
+            fk_column = self.quote_column(Relationship.get_cascade_fk_column(child)) # Toggle
             pk_column = self.quote_column(dataset.frm[child].pk_column)
             child_table = self.quote_table(child)
             select_clause = f'SELECT {child_table}.{pk_column} FROM {child} '

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -4610,7 +4610,7 @@ class SQLDriver:
                 return DELETE_RECURSION_LIMIT_ERROR
 
             # Get data for query
-            fk_column = self.quote_column(Relationship.get_cascade_fk_column(child, dataset.frm))
+            fk_column = self.quote_column(Relationship.get_cascade_fk_column(child))
             child_table = self.quote_table(child)
 
             # Create new inner join and add it to beginning of passed in inner_join

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -162,6 +162,15 @@ SEARCH_RETURNED: int = 2  # A result was found
 SEARCH_ABORTED: int = 4   # The search was aborted, likely during a callback
 SEARCH_ENDED: int = 8     # We have reached the end of the search
 
+# ----------------------------
+# DELETE RETURNS BITMASKS
+# ----------------------------
+DELETE_FAILED: int = 1    # No result was found
+DELETE_RETURNED: int = 2  # A result was found
+DELETE_ABORTED: int = 4   # The search was aborted, likely during a callback
+DELETE_HIT_RECURSION_LIMIT: int = 8     # We hit max nested levels
+DELETE_CASCADE_RECURSION_LIMIT = 15 # This is mysql's max level when using foreign key CASCADE DELETE
+
 # -------
 # CLASSES
 # -------
@@ -4570,24 +4579,53 @@ class SQLDriver:
         return q
 
     def delete_record(self, dataset: DataSet, cascade=True): # TODO: get ON DELETE CASCADE from db
-        # Delete child records first!
-        if cascade:
-            child_deleted = []
-            for _ in dataset.frm.datasets:
-                for r in dataset.frm.relationships:
-                    if r.parent_table == dataset.table and r.update_cascade and (r.child_table not in child_deleted):
-                        child = self.quote_table(r.child_table)
-                        child_deleted.append(child)
-                        fk_column = self.quote_column(r.fk_column)
-                        q = f'DELETE FROM {child} WHERE {fk_column}={dataset.get_current(dataset.pk_column)}'
-                        self.execute(q)
-                        logger.debug(f'Delete query executed: {q}')
-                        dataset.frm[r.child_table].requery(False)
-
+        # Get data for query
         table = self.quote_table(dataset.table)
         pk_column = self.quote_column(dataset.pk_column)
-        q = f'DELETE FROM {table} WHERE {pk_column}={dataset.get_current(dataset.pk_column)};'
+        pk = dataset.get_current(dataset.pk_column)
+        
+        # Create clauses
+        delete_clause = f'DELETE FROM {table} ' # leave a space at end for joining
+        where_clause = f'WHERE {table}.{pk_column} = {pk} ' # leave a space at end for joining
+
+        # Delete child records first!
+        if cascade:
+            recursion = 0
+            self.delete_record_recursive(dataset, delete_clause, '', where_clause, table, pk_column, recursion)
+        
+        # Then delete self
+        q = delete_clause + where_clause + ";"
         return self.execute(q)
+    
+    def delete_record_recursive(self, dataset: DataSet, delete_clause, inner_join, where_clause, parent, pk_column, recursion):
+        for child in Relationship.get_cascaded_relationships(dataset.key):
+            # Check to make sure we arn't at recursion limit
+            recursion += 1 # Increment, since this is a child
+            if recursion >= DELETE_CASCADE_RECURSION_LIMIT:
+                return DELETE_HIT_RECURSION_LIMIT
+
+            # Get data for query
+            fk_column = self.quote_column(Relationship.get_cascade_fk_column(child, dataset.frm))
+            child_table = self.quote_table(child)
+
+            # Create new inner join and add it to beginning of passed in inner_join
+            inner_join_clause = f'INNER JOIN {child} ON {parent}.{pk_column} = {child}.{fk_column} {inner_join}'
+
+            # Call function again to create recursion
+            result = self.delete_record_recursive(dataset.frm[child], delete_clause, inner_join_clause,
+                                                  where_clause, child, self.quote_column(dataset.frm[child].pk_column), recursion)
+
+            # Break out of recursive call if at recursion limit
+            if result == DELETE_HIT_RECURSION_LIMIT:
+                return DELETE_HIT_RECURSION_LIMIT
+            
+            # Create query and execute
+            q = delete_clause + inner_join_clause + where_clause
+            self.execute(q)
+            logger.debug(f'Delete query executed: {q}')
+
+            # Reset limit for next Child stack
+            recursion = 0
 
     def duplicate_record(self, dataset: DataSet, cascade: bool) -> ResultSet:
         ## https://stackoverflow.com/questions/1716320/how-to-insert-duplicate-rows-in-sqlite-with-a-unique-id


### PR DESCRIPTION
This was easier than I thought.

Here's how it works on my parent/child/grandchild/great-grandchild table:

```
INFO:pysimplesql.pysimplesql:Executing query: DELETE FROM person INNER JOIN service ON bike_repair.id = service.bike_repair_id INNER JOIN bike_repair ON bike.id = bike_repair.bike_id INNER JOIN bike ON person.id = bike.person_id WHERE person.id = 1  None
INFO:pysimplesql.pysimplesql:Executing query: DELETE FROM person INNER JOIN bike_repair ON bike.id = bike_repair.bike_id INNER JOIN bike ON person.id = bike.person_id WHERE person.id = 1  None
INFO:pysimplesql.pysimplesql:Executing query: DELETE FROM person INNER JOIN bike ON person.id = bike.person_id WHERE person.id = 1  None
INFO:pysimplesql.pysimplesql:Executing query: DELETE FROM person INNER JOIN car ON person.id = car.person_id WHERE person.id = 1  None
INFO:pysimplesql.pysimplesql:Executing query: DELETE FROM person WHERE person.id = 1 ; None
```

After this lands, I'll copy in the new delete_cascade sqlite sqldriver. I also have a plan to allow for pysimplesql v2 database compatibility.