### PR TITLE
Cleaning up prompt_save, autosave

### DIFF
--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -396,8 +396,8 @@ class DataSet:
                "ORDER BY {description_column} ASC"
         :param filtered: (optional) If True, the relationships will be considered and an appropriate WHERE clause will
                be generated. False will display all records in query.
-        :param prompt_save: (optional) Prompt to save changes when dirty records are present.
-        :param prompt_silent: (optional) Default: False. True to save when changes are found without prompting the user.
+        :param prompt_save: (optional) Default: `Form.prompt_save_`. Prompt to save changes when dirty records are present.
+        :param prompt_silent: (optional) Default: `Form.prompt_silent`. True to save when changes are found without prompting the user.
         :returns: None
         """
         DataSet.instances.append(self)


### PR DESCRIPTION
Per PEP8, put leading _ is for weak internal use, but really we are using it to avoid clashing with function name. So renamed variables to prompt_save_.

Added prompt_save_ to Form, so we can pass down initially set prompt_save_ to Datasets.

Renamed autosave to prompt_silent. This makes it more clear that it is a mode of prompt_save. Passed initially set prompt_silent to Datasets. Added it to set_prompt_save