### PR TITLE
MySQL Docker now working

### DIFF
--- a/examples/MySQL_examples/docker/Docker_create.py
+++ b/examples/MySQL_examples/docker/Docker_create.py
@@ -32,7 +32,7 @@ with tqdm(total=1, desc="Building Docker image") as pbar:
 print("Starting container...")
 with tqdm(total=1, desc="Starting container") as pbar:
     container = client.containers.run(
-        image, name="pysimplesql-mysql", detach=True, ports={"3306/tcp": 3306}
+        image, name="pysimplesql-examples-mysql", detach=True, ports={"3306/tcp": 3306}
     )
     pbar.update()
 

--- a/examples/MySQL_examples/docker/Dockerfile
+++ b/examples/MySQL_examples/docker/Dockerfile
@@ -1,11 +1,11 @@
-# dump build stage
-FROM mysql as builder
+FROM mysql:latest
 
-#RUN ["sed", "-i", "s/exec \"$@\"/echo \"skipping...\"/", "/usr/local/bin/docker-entrypoint.sh"]
-ENV MYSQL_USER=pysimplesql_user
-ENV MYSQL_PASSWORD=pysimplesql
-ENV MYSQL_ROOT_PASSWORD=pysimplesq
-ENV MYSQL_DATABASE=pysimplesql_examples
+# Set the environment variables for MySQL
+ENV MYSQL_DATABASE pysimplesql_examples
+ENV MYSQL_USER pysimplesql_user
+ENV MYSQL_PASSWORD pysimplesql
+ENV MYSQL_ROOT_PASSWORD pysimplesql
 
-COPY Journal.sql /docker-entrypoint-initdb.d/Journal.sql
+# Copy the SQL script to initialize the database
+COPY Journal.sql /docker-entrypoint-initdb.d/
 

--- a/examples/MySQL_examples/journal_mysql_docker.py
+++ b/examples/MySQL_examples/journal_mysql_docker.py
@@ -57,10 +57,10 @@ layout = [
     [ss.field("Journal.entry", sg.MLine, size=(71, 20))],
 ]
 mysql_docker = {
-    'user': 'pysimplesql_user',
-    'password': 'pysimplesql',
-    'host': '127.0.0.1',
-    'database': 'pysimplesql_examples'
+    "user": "pysimplesql_user",
+    "password": "pysimplesql",
+    "host": "127.0.0.1",
+    "database": "pysimplesql_examples",
 }
 # Create the Window, Driver and Form
 win = sg.Window("Journal example: MySQL", layout, finalize=True)

--- a/examples/MySQL_examples/journal_mysql_docker.py
+++ b/examples/MySQL_examples/journal_mysql_docker.py
@@ -5,19 +5,19 @@ import logging
 
 # Set the logging level here (NOTSET,DEBUG,INFO,WARNING,ERROR,CRITICAL)
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 
-# POSTGRESQL EXAMPLE USING DOCKER TO PROVIDE A POSTGRES SERVER
+# MYSQL EXAMPLE USING DOCKER TO PROVIDE A MYSQL SERVER
 # Note that docker must be installed and configured properly on your local machine.
-# Load in the docker image and create a container to run the Postgres server.
-# See the Journal.sql file in the PostgreSQL_examples/docker folder to see the SQL
+# Load in the docker image and create a container to run the MySQL server.
+# See the Journal.sql file in the MySQL_examples/docker folder to see the SQL
 # statements that were used to create the database.
 docker_image = "pysimplesql/examples:mysql"
 docker_image_pull(docker_image)
 docker_container = docker_container_start(
     image=docker_image,
     container_name="pysimplesql-examples-mysql",
-    ports={"3306/tcp": ("127.0.0.1", 3306)},
+    ports={"3306/tcp": ("127.0.0.1", "3306")},
 )
 
 # -------------------------
@@ -56,17 +56,15 @@ layout = [
     [ss.field("Journal.title")],
     [ss.field("Journal.entry", sg.MLine, size=(71, 20))],
 ]
-postgres_docker = {
+mysql_docker = {
     "host": "localhost",
     "user": "pysimplesql_user",
     "password": "pysimplesql",
     "database": "pysimplesql_examples",
 }
 # Create the Window, Driver and Form
-win = sg.Window("Journal example: PostgreSQL", layout, finalize=True)
-driver = ss.Postgres(
-    **postgres_docker
-)  # Use the postgres examples database credentials
+win = sg.Window("Journal example: MySQL", layout, finalize=True)
+driver = ss.Mysql(**mysql_docker)  # Use the postgres examples database credentials
 frm = ss.Form(driver, bind_window=win)  # <=== Here is the magic!
 
 # Reverse the default sort order so new journal entries appear at the top

--- a/examples/MySQL_examples/journal_mysql_docker.py
+++ b/examples/MySQL_examples/journal_mysql_docker.py
@@ -17,7 +17,7 @@ docker_image_pull(docker_image)
 docker_container = docker_container_start(
     image=docker_image,
     container_name="pysimplesql-examples-mysql",
-    ports={"3306/tcp": ("127.0.0.1", "3306")},
+    ports={"3306/tcp": ("127.0.0.1", 3306)},
 )
 
 # -------------------------
@@ -57,14 +57,14 @@ layout = [
     [ss.field("Journal.entry", sg.MLine, size=(71, 20))],
 ]
 mysql_docker = {
-    "host": "localhost",
-    "user": "pysimplesql_user",
-    "password": "pysimplesql",
-    "database": "pysimplesql_examples",
+    'user': 'pysimplesql_user',
+    'password': 'pysimplesql',
+    'host': '127.0.0.1',
+    'database': 'pysimplesql_examples'
 }
 # Create the Window, Driver and Form
 win = sg.Window("Journal example: MySQL", layout, finalize=True)
-driver = ss.Mysql(**mysql_docker)  # Use the postgres examples database credentials
+driver = ss.Mysql(**mysql_docker)  # Use the database credentials
 frm = ss.Form(driver, bind_window=win)  # <=== Here is the magic!
 
 # Reverse the default sort order so new journal entries appear at the top

--- a/pysimplesql/docker_utils.py
+++ b/pysimplesql/docker_utils.py
@@ -150,7 +150,10 @@ def docker_container_start(
         container.reload()
         if container.status == "running":
             logs = container.logs().decode("utf-8")
-            if "database system is ready to accept connections" in logs:
+            # TODO: Refactor to include callback or other mechanism to determine if
+            # a container is fully initialized, since this needs to be more general
+            # purpose. For now, this should work in both Postgres and MySQL
+            if "ready" in logs and "connect" in logs:
                 logger.info("Ready to connect!")
                 break
         time.sleep(1)

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -6693,14 +6693,24 @@ class Mysql(SQLDriver):
 
         self.win_pb.close()
 
-    def connect(self):
-        return mysql.connector.connect(
-            host=self.host,
-            user=self.user,
-            password=self.password,
-            database=self.database,
-            port="3306"
-        )
+    def connect(self, retries=3):
+        attempt = 0
+        while attempt < retries:
+            try:
+                con = mysql.connector.connect(
+                    host=self.host,
+                    user=self.user,
+                    password=self.password,
+                    database=self.database,
+                    # connect_timeout=3,
+                )
+                return con
+            except mysql.connector.Error as e:
+                print(f"Failed to connect to database ({attempt + 1}/{retries})")
+                print(e)
+                attempt += 1
+                sleep(1)
+        raise Exception("Failed to connect to database")
 
     def execute(
         self,

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -6762,7 +6762,11 @@ class Mysql(SQLDriver):
         for row in rows:
             name = row["Field"]
             # Check if the value is a bytes-like object, and decode if necessary
-            type_value = row["Type"].decode('utf-8') if isinstance(row["Type"], bytes) else row["Type"]
+            type_value = (
+                row["Type"].decode("utf-8")
+                if isinstance(row["Type"], bytes)
+                else row["Type"]
+            )
             # Capitalize and get rid of the extra information of the row type
             # I.e. varchar(255) becomes VARCHAR
             domain = type_value.split("(")[0].upper()

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -6699,6 +6699,7 @@ class Mysql(SQLDriver):
             user=self.user,
             password=self.password,
             database=self.database,
+            port="3306"
         )
 
     def execute(
@@ -6737,10 +6738,10 @@ class Mysql(SQLDriver):
 
     def get_tables(self):
         query = (
-            "SELECT table_name FROM information_schema.tables WHERE table_schema = %s"
+            "SELECT TABLE_NAME FROM information_schema.tables WHERE table_schema = %s"
         )
         rows = self.execute(query, [self.database], silent=True)
-        return [row["table_name"] for row in rows]
+        return [row["TABLE_NAME"] for row in rows]
 
     def column_info(self, table):
         # Return a list of column names
@@ -6750,9 +6751,11 @@ class Mysql(SQLDriver):
 
         for row in rows:
             name = row["Field"]
+            # Check if the value is a bytes-like object, and decode if necessary
+            type_value = row["Type"].decode('utf-8') if isinstance(row["Type"], bytes) else row["Type"]
             # Capitalize and get rid of the extra information of the row type
             # I.e. varchar(255) becomes VARCHAR
-            domain = row["Type"].split("(")[0].upper()
+            domain = type_value.split("(")[0].upper()
             notnull = row["Null"] == "NO"
             default = row["Default"]
             pk = row["Key"] == "PRI"


### PR DESCRIPTION
Docker now working and providing a MySQL server for the example.  I have a little more work to do with the image to make the data persist and not start fresh each time, but I will work on that as a separate issue.

There was also a problem with the Mysql SQLDriver for getting table names and getting column info.  I'm not sure of the exact reason, but the HelioHost table_name field is lower case, and the Docker container MySQL server returned TABLE_NAME.  This could be because of different MySQL versions, or because of the change from the mysql-connector library to the mysql-connector-python library.

A similar issue was found with getting column info - the sql data type (domain) was being returned as a string from HelioHost, but as a bytes object from the Docker MySQL server.  Again, it could be from the library change or the MySQL version difference.