### PR TITLE
Adding quote_table for sqlite

### DIFF
--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -6646,7 +6646,12 @@ class Sqlite(SQLDriver):
     def __init__(
         self, db_path=None, sql_script=None, sqlite3_database=None, sql_commands=None
     ):
-        super().__init__(name="SQLite", placeholder="?")
+        super().__init__(
+            name="SQLite",
+            placeholder="?",
+            table_quote='"',
+            column_quote='"',
+        )
 
         new_database = False
         if db_path is not None:

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -6733,7 +6733,7 @@ class Sqlite(SQLDriver):
 
     def column_info(self, table):
         # Return a list of column names
-        q = f"PRAGMA table_info({table})"
+        q = f"PRAGMA table_info({self.quote_table(table)})"
         rows = self.execute(q, silent=True)
         names = []
         col_info = ColumnInfo(self, table)
@@ -6754,7 +6754,7 @@ class Sqlite(SQLDriver):
         return col_info
 
     def pk_column(self, table):
-        q = f"PRAGMA table_info({table})"
+        q = f"PRAGMA table_info({self.quote_table(table)})"
         row = self.execute(q, silent=True).fetchone()
 
         return row["name"] if "name" in row else None
@@ -6764,7 +6764,9 @@ class Sqlite(SQLDriver):
         relationships = []
         tables = self.get_tables()
         for from_table in tables:
-            rows = self.execute(f"PRAGMA foreign_key_list({from_table})", silent=True)
+            rows = self.execute(
+                f"PRAGMA foreign_key_list({self.quote_table(from_table)})", silent=True
+            )
 
             for row in rows:
                 dic = {}


### PR DESCRIPTION
I just ran into this today, working to setup a form using an [example Northwind database](https://github.com/jpwhite3/northwind-SQLite3) 

The example had 'Order Details' with a space. I think it was a mistake, but obviously pysimplesql didn't like that. 

- Is this so un-common, its not worth even caring about?
- If we should try to fix, should we quote by default? Single, double? 
- What about column_quote?

Do we hard-code it?

`super().__init__(name="SQLite", placeholder="?", table_quote=""")`

Or let the user pass a quote option when setting up the SqlDriver?

`ss.Driver.sqlite("./northwind.db", table_quote="'")`
