### PR TITLE
Add sql_script_encoding, default "utf-8", to pass to execute_script

### DIFF
--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -6644,7 +6644,12 @@ class Sqlite(SQLDriver):
     """
 
     def __init__(
-        self, db_path=None, sql_script=None, sqlite3_database=None, sql_commands=None
+        self,
+        db_path=None,
+        sql_script=None,
+        sql_script_encoding: str = "utf-8",
+        sqlite3_database=None,
+        sql_commands=None,
     ):
         super().__init__(name="SQLite", placeholder="?")
 
@@ -6671,7 +6676,7 @@ class Sqlite(SQLDriver):
         if sql_script is not None and new_database:
             # run SQL script from the file if the database does not yet exist
             logger.info("Executing sql script from file passed in")
-            self.execute_script(sql_script)
+            self.execute_script(sql_script, sql_script_encoding)
 
         self.db_path = db_path
         self.win_pb.close()
@@ -6784,8 +6789,8 @@ class Sqlite(SQLDriver):
                 relationships.append(dic)
         return relationships
 
-    def execute_script(self, script):
-        with open(script, "r") as file:
+    def execute_script(self, script, encoding):
+        with open(script, "r", encoding=encoding) as file:
             logger.info(f"Loading script {script} into database.")
             self.con.executescript(file.read())
 


### PR DESCRIPTION
`with open` was using the local cp1252, rather than utf-8 on my lappy.

That created problems when executing the Northwind sql script with unicode names.

I think utf-8 be default makes sense. When you're not on a deadline, let me know if that makes sense to you.

