### PR TITLE
Import modules when init sqldriver driver

### DIFF
--- a/examples/MSAccess_examples/install_java.py
+++ b/examples/MSAccess_examples/install_java.py
@@ -6,11 +6,16 @@ with the UCanAccess java JDBC driver, which requires Java to be installed in ord
 run.  This also serves as an example to automatically download a local Java installation
 for your own projects.
 """
-import jdk
 import os
 import pysimplesql as ss
 import PySimpleGUI as sg
 import subprocess
+
+try:
+    import jdk
+except ModuleNotFoundError:
+    sg.popup_error("You must `pip install install-jdk` to use this example")
+    exit(0)
 
 
 # -------------------------------------------------


### PR DESCRIPTION
Using my new write powers to work in the main pysimplesql repository! Now you can easily try out my changes before committing :)

This loads modules necessary for the sqldriver drivers on their init, with a popup if module is not found. So now a user doesn't need to install all database drivers, just to use sqlite. Then we can add all the [optionals to setup.py](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies) 

I tested this, and it works ok... but let me know if there is a more clean way without using global.

What are your thoughts on external requirements? Like the ODBC for sqlserver, or java jre for access?