### PR TITLE
Replace threaded info close

### DIFF
--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -3748,30 +3748,11 @@ class Popup:
                 element_justification="center",
                 ttk_theme=themepack.ttk_theme,
             )
-            self._auto_close(popup_win, auto_close_seconds)
-
-    def _auto_close(self, window: sg.Window, seconds: int):
-        """
-        Internal use only.
-
-        Uses an invisible window to close info popup
-
-        :param window: sg.Window object to close
-        :param seconds: Seconds to keep window open
-        :returns: None
-        """
-        layout = [[sg.Text("Invisible window")]]
-        invisible_window = sg.Window(
-            "Invisible window that stays open",
-            layout,
-            alpha_channel=0,
-        )
-        while True:  # The Event Loop
-            event, values = window.read(timeout=seconds * 1000)
-            if event == "__TIMEOUT__":
-                window.close()
-                break
-        invisible_window.close()
+            while True:
+                event, values = popup_win.read(timeout=auto_close_seconds * 1000)
+                if event == "__TIMEOUT__":
+                    popup_win.close()
+                    break
 
 
 class ProgressBar:

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -3639,7 +3639,7 @@ class Popup:
         Create a new Popup instance
         :returns: None.
         """
-        self.last_info_msg = ""
+        self.last_info_msg: str = ""
         self.popup_info = None
 
     def ok(self, title, msg):
@@ -3732,12 +3732,6 @@ class Popup:
             themepack.info_popup_auto_close_seconds by default.
         :returns: None
         """
-        """
-        Internal use only.
-
-        Creates sg.Window with no buttons, auto-closing after seconds as defined in
-        themepack
-        """
         title = lang.info_popup_title
         if auto_close_seconds is None:
             auto_close_seconds = themepack.popup_info_auto_close_seconds
@@ -3755,28 +3749,30 @@ class Popup:
                 element_justification="center",
                 ttk_theme=themepack.ttk_theme,
             )
-            threading.Thread(
-                target=self.auto_close,
-                args=(self.popup_info, auto_close_seconds),
-                daemon=True,
-            ).start()
+            self._auto_close(self.popup_info, auto_close_seconds)
 
-    def auto_close(self, window: sg.Window, seconds: int):
+    def _auto_close(self, window: sg.Window, seconds: int):
         """
-        Use in a thread to automatically close the passed in sg.Window.
+        Internal use only.
+
+        Uses an invisible window to close info popup
 
         :param window: sg.Window object to close
         :param seconds: Seconds to keep window open
         :returns: None
         """
-        step = 1
-        while step <= seconds:
-            sleep(1)
-            step += 1
-        self.close(window)
-
-    def close(self, window):
-        window.close()
+        layout = [[sg.Text("Invisible window")]]
+        invisible_window = sg.Window(
+            "Invisible window that stays open",
+            layout,
+            alpha_channel=0,
+        )
+        while True:  # The Event Loop
+            event, values = window.read(timeout=seconds * 1000)
+            if event == "__TIMEOUT__":
+                window.close()
+                break
+        invisible_window.close()
 
 
 class ProgressBar:

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -3631,7 +3631,7 @@ class Popup:
     """
     Popup helper class.
 
-    Has popup functions for internal use. Stores last info popup as last_info
+    Has popup functions for internal use. Stores last info popup text as last_info_msg
     """
 
     def __init__(self):
@@ -3640,7 +3640,6 @@ class Popup:
         :returns: None.
         """
         self.last_info_msg: str = ""
-        self.popup_info = None
 
     def ok(self, title, msg):
         """
@@ -3739,7 +3738,7 @@ class Popup:
         if display_message:
             msg = msg.splitlines()
             layout = [sg.T(line, font="bold") for line in msg]
-            self.popup_info = sg.Window(
+            popup_win = sg.Window(
                 title=title,
                 layout=[layout],
                 no_titlebar=False,
@@ -3749,7 +3748,7 @@ class Popup:
                 element_justification="center",
                 ttk_theme=themepack.ttk_theme,
             )
-            self._auto_close(self.popup_info, auto_close_seconds)
+            self._auto_close(popup_win, auto_close_seconds)
 
     def _auto_close(self, window: sg.Window, seconds: int):
         """


### PR DESCRIPTION
This replaces the old un-thread-safe version with a simpler concept (that doesn't have issues when mucking around in tkinter binds/calls!)

You can wait to merge this until pandas has been merged back in, just to be safe.