### PR TITLE
Fix prompt save dataloss

### DIFF
--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -147,10 +147,9 @@ SHOW_MESSAGE: int = 4096
 # ---------------------------
 # PROMPT_SAVE RETURN BITMASKS
 # ---------------------------
-PROMPT_SAVE_DISCARDED: int = 1
 PROMPT_SAVE_PROCEED: int = 2
 PROMPT_SAVE_NONE: int = 4
-
+PROMPT_SAVE_DISCARDED: int = 8
 # ---------------------------
 # PROMPT_SAVE MODES
 # ---------------------------
@@ -948,7 +947,10 @@ class DataSet:
                     )
                     & SAVE_FAIL
                 ):
-                    return PROMPT_SAVE_DISCARDED
+                    logger.debug("Save failed during prompt-save. Resetting selectors")
+                    # set all selectors back to previous position
+                    self.frm.update_selectors()
+                    return SAVE_FAIL
                 return PROMPT_SAVE_PROCEED
             # if no
             self.purge_virtual()
@@ -1099,7 +1101,8 @@ class DataSet:
         logger.debug(f"Moving to the first record of table {self.table}")
         if skip_prompt_save is False:
             # don't update self/dependents if we are going to below anyway
-            self.prompt_save(update_elements=False)
+            if self.prompt_save(update_elements=False) == SAVE_FAIL:
+                return
 
         self.current_index = 0
         if update_elements:
@@ -1133,7 +1136,8 @@ class DataSet:
         logger.debug(f"Moving to the last record of table {self.table}")
         if skip_prompt_save is False:
             # don't update self/dependents if we are going to below anyway
-            self.prompt_save(update_elements=False)
+            if self.prompt_save(update_elements=False) == SAVE_FAIL:
+                return
 
         self.current_index = len(self.rows.index) - 1
         if update_elements:
@@ -1168,7 +1172,8 @@ class DataSet:
             logger.debug(f"Moving to the next record of table {self.table}")
             if skip_prompt_save is False:
                 # don't update self/dependents if we are going to below anyway
-                self.prompt_save(update_elements=False)
+                if self.prompt_save(update_elements=False) == SAVE_FAIL:
+                    return
 
             self.current_index += 1
             if update_elements:
@@ -1203,7 +1208,8 @@ class DataSet:
             logger.debug(f"Moving to the previous record of table {self.table}")
             if skip_prompt_save is False:
                 # don't update self/dependents if we are going to below anyway
-                self.prompt_save(update_elements=False)
+                if self.prompt_save(update_elements=False) == SAVE_FAIL:
+                    return
 
             self.current_index -= 1
             if update_elements:
@@ -1337,7 +1343,8 @@ class DataSet:
                 # discard virtual or update after save
                 omit_elements = []
             # don't update self/dependents if we are going to below anyway
-            self.prompt_save(update_elements=False)
+            if self.prompt_save(update_elements=False) == SAVE_FAIL:
+                return
 
         self.current_index = index
         if update_elements:
@@ -1383,7 +1390,8 @@ class DataSet:
                 # discard virtual or update after save
                 omit_elements = []
             # don't update self/dependents if we are going to below anyway
-            self.prompt_save(update_elements=False)
+            if self.prompt_save(update_elements=False) == SAVE_FAIL:
+                return
 
         # Move to the numerical index of where the primary key is located.
         # If the pk value can't be found, move to the last index
@@ -1530,7 +1538,8 @@ class DataSet:
         # todo: bring back the values parameter?
         if skip_prompt_save is False:
             # don't update self/dependents if we are going to below anyway
-            self.prompt_save(update_elements=False)
+            if self.prompt_save(update_elements=False) == SAVE_FAIL:
+                return
 
         # Don't insert if parent has no records or is virtual
         parent_table = Relationship.get_parent(self.table)

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -1099,10 +1099,13 @@ class DataSet:
         :returns: None
         """
         logger.debug(f"Moving to the first record of table {self.table}")
-        if skip_prompt_save is False:
+        # prompt_save
+        if (
+            not skip_prompt_save
             # don't update self/dependents if we are going to below anyway
-            if self.prompt_save(update_elements=False) == SAVE_FAIL:
-                return
+            and self.prompt_save(update_elements=False) == SAVE_FAIL
+        ):
+            return
 
         self.current_index = 0
         if update_elements:
@@ -1134,10 +1137,13 @@ class DataSet:
         :returns: None
         """
         logger.debug(f"Moving to the last record of table {self.table}")
-        if skip_prompt_save is False:
+        # prompt_save
+        if (
+            not skip_prompt_save
             # don't update self/dependents if we are going to below anyway
-            if self.prompt_save(update_elements=False) == SAVE_FAIL:
-                return
+            and self.prompt_save(update_elements=False) == SAVE_FAIL
+        ):
+            return
 
         self.current_index = len(self.rows.index) - 1
         if update_elements:
@@ -1170,10 +1176,13 @@ class DataSet:
         """
         if self.current_index < len(self.rows.index) - 1:
             logger.debug(f"Moving to the next record of table {self.table}")
-            if skip_prompt_save is False:
+            # prompt_save
+            if (
+                not skip_prompt_save
                 # don't update self/dependents if we are going to below anyway
-                if self.prompt_save(update_elements=False) == SAVE_FAIL:
-                    return
+                and self.prompt_save(update_elements=False) == SAVE_FAIL
+            ):
+                return
 
             self.current_index += 1
             if update_elements:
@@ -1206,10 +1215,13 @@ class DataSet:
         """
         if self.current_index > 0:
             logger.debug(f"Moving to the previous record of table {self.table}")
-            if skip_prompt_save is False:
+            # prompt_save
+            if (
+                not skip_prompt_save
                 # don't update self/dependents if we are going to below anyway
-                if self.prompt_save(update_elements=False) == SAVE_FAIL:
-                    return
+                and self.prompt_save(update_elements=False) == SAVE_FAIL
+            ):
+                return
 
             self.current_index -= 1
             if update_elements:
@@ -1265,9 +1277,13 @@ class DataSet:
             return SEARCH_ABORTED
 
         # TODO: Should this be before the before_search callback?
-        if skip_prompt_save is False:
+        # prompt_save
+        if (
+            not skip_prompt_save
             # don't update self/dependents if we are going to below anyway
-            self.prompt_save(update_elements=False)
+            and self.prompt_save(update_elements=False) == SAVE_FAIL
+        ):
+            return None
 
         # First lets make a search order.. TODO: remove this hard coded garbage
         if len(self.rows.index):
@@ -1536,10 +1552,13 @@ class DataSet:
         # todo: this is currently filtered out by enabling of the element, but it should
         #  be filtered here too!
         # todo: bring back the values parameter?
-        if skip_prompt_save is False:
+        # prompt_save
+        if (
+            not skip_prompt_save
             # don't update self/dependents if we are going to below anyway
-            if self.prompt_save(update_elements=False) == SAVE_FAIL:
-                return
+            and self.prompt_save(update_elements=False) == SAVE_FAIL
+        ):
+            return
 
         # Don't insert if parent has no records or is virtual
         parent_table = Relationship.get_parent(self.table)

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -2134,9 +2134,14 @@ class DataSet:
         :param skip_prompt_save: (Optional) True to skip prompting to save dirty records
         :returns: None
         """
+        # prompt_save
+        if (
+            not skip_prompt_save
+            # don't update self/dependents if we are going to below anyway
+            and self.prompt_save(update_elements=False) == SAVE_FAIL
+        ):
+            return
 
-        if skip_prompt_save is False:
-            self.frm.prompt_save()
         # Reset the keygen to keep consistent naming
         logger.info("Creating Quick Editor window")
         keygen.reset()


### PR DESCRIPTION
If a save fails during a prompt-save, now we:

1) update_selectors() - do this for all selectors, because prompt-save might have been prompted by parent, while save_fail came from dependent. 
2) return SAVE_FAIL, which now will return in set_by_index/pk/first/prev/next/last

https://user-images.githubusercontent.com/57631333/235143763-e39387f3-27a4-4265-b707-8f9a3706fb90.mp4

