### PR TITLE
Smarter updating after save

### DIFF
--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -1058,13 +1058,6 @@ class DataSet:
             if vrows and update_elements:
                 self.frm.update_elements(self.key)
 
-            # if the description_column has changed, make sure to update other elements
-            # that may depend on it, that otherwise wouldn't be requeried.
-            to_update = Relationship.get_dependent_columns(self.frm, self.table)
-            for key, col in to_update.items():
-                self.frm.update_fields(key, combobox_values_only=True)
-                if self.frm[key].tableview_displays_column(col):
-                    self.frm.update_selectors(key)
             return PROMPT_SAVE_DISCARDED
         # if no changes
         return PROMPT_SAVE_NONE
@@ -2374,7 +2367,7 @@ class DataSet:
             backup = target_table.get_original_current_row()
         lst = []
         for _, r in target_table.rows.sort_index().iterrows():
-            if backup and backup[pk_column] == r[pk_column]:
+            if backup is not None and backup[pk_column] == r[pk_column]:
                 lst.append(ElementRow(backup[pk_column].tolist(), backup[description]))
             else:
                 lst.append(ElementRow(r[pk_column], r[description]))

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -1929,7 +1929,7 @@ class DataSet:
                 to_update = Relationship.get_dependent_columns(self.frm, self.table)
                 for key, col in to_update.items():
                     self.frm.update_fields(key, combo_values_only=True)
-                    if self.frm[key].tableview_displays_column(col):
+                    if self.frm[key].column_in_tableheading(col):
                         self.frm.update_selectors(key)
 
         logger.debug("Record Saved!")
@@ -2274,7 +2274,7 @@ class DataSet:
         if not self.current_row_has_backup:
             self.rows.attrs["row_backup"] = self.get_current_row().copy()
 
-    def tableview_values(
+    def table_values(
         self, columns: List[str] = None, mark_virtual: bool = False
     ) -> List[TableRow]:
         """
@@ -2329,9 +2329,9 @@ class DataSet:
 
         return values
 
-    def tableview_displays_column(self, column: str) -> bool:
+    def column_in_tableheading(self, column: str) -> bool:
         """
-        Returns if tableview displays column.
+        Returns True if column is found in TableHeading
 
         :param column: The name of the column
         :returns: True if column is displayed, else False.
@@ -3846,7 +3846,7 @@ class Form:
             elif type(mapped.element) is sg.PySimpleGUI.Table:
                 # Tables use an array of arrays for values.  Note that the headings
                 # can't be changed.
-                values = mapped.dataset.tableview_values()
+                values = mapped.dataset.table_values()
                 # Select the current one
                 pk = mapped.dataset.get_current_pk()
 
@@ -3985,7 +3985,7 @@ class Form:
                         except KeyError:
                             columns = None  # default to all columns
 
-                        values = dataset.tableview_values(columns, mark_virtual=True)
+                        values = dataset.table_values(columns, mark_virtual=True)
 
                         # Get the primary key to select.
                         # Use the list above instead of getting it directly
@@ -5714,7 +5714,7 @@ class _CellEdit:
             col_idx = int(treeview.identify_column(event.x)[1:]) - 1
 
         try:
-            data_key, element = self.get_datakey_and_tableview(treeview, self.frm)
+            data_key, element = self.get_datakey_and_sgtable(treeview, self.frm)
         except TypeError:
             return
 
@@ -5933,7 +5933,7 @@ class _CellEdit:
         # otherwise, accept
         self.accept(**accept_dict)
 
-    def get_datakey_and_tableview(self, treeview, frm):
+    def get_datakey_and_sgtable(self, treeview, frm):
         # loop through datasets, trying to identify sg.Table selector
         for data_key in [
             data_key for data_key in frm.datasets if len(frm[data_key].selector)
@@ -6027,7 +6027,7 @@ class _LiveUpdate:
                     dataset.set_current(column, new_value)
 
                     # Update tableview if uses column:
-                    if dataset.tableview_displays_column(column):
+                    if dataset.column_in_tableheading(column):
                         self.frm.update_selectors(dataset.key)
 
     def delay(self, widget, widget_type):

--- a/pysimplesql/pysimplesql.py
+++ b/pysimplesql/pysimplesql.py
@@ -1928,7 +1928,7 @@ class DataSet:
             if column == self.description_column:
                 to_update = Relationship.get_dependent_columns(self.frm, self.table)
                 for key, col in to_update.items():
-                    self.frm.update_fields(key, combobox_values_only=True)
+                    self.frm.update_fields(key, combo_values_only=True)
                     if self.frm[key].tableview_displays_column(col):
                         self.frm.update_selectors(key)
 
@@ -2366,7 +2366,7 @@ class DataSet:
         if target_table.current_row_has_backup:
             backup = target_table.get_original_current_row()
         lst = []
-        for _, r in target_table.rows.sort_index().iterrows():
+        for _, r in target_table.rows.iterrows():
             if backup is not None and backup[pk_column] == r[pk_column]:
                 lst.append(ElementRow(backup[pk_column].tolist(), backup[description]))
             else:
@@ -3729,7 +3729,7 @@ class Form:
         target_data_key: str = None,
         omit_elements: List[str] = None,
         column_names: List[str] = None,
-        combobox_values_only: bool = False,
+        combo_values_only: bool = False,
     ) -> None:
         """
         Updated the field elements to reflect their `rows` DataFrame for this `Form`
@@ -3739,8 +3739,7 @@ class Form:
             updates elements for all datasets
         :param omit_elements: A list of elements to omit updating
         :param column_names: A list of column names to update
-        :param comboboxes_only: Updates the value list only for comboboxes. This option
-            will fail if adding or deleting entries.
+        :param combo_values_only: Updates the value list only for comboboxes.
         """
         if omit_elements is None:
             omit_elements = []
@@ -3764,7 +3763,7 @@ class Form:
                 continue
 
             if (
-                combobox_values_only
+                combo_values_only
                 and type(mapped.element) is not sg.PySimpleGUI.Combo
             ):
                 continue
@@ -3831,9 +3830,12 @@ class Form:
                     mapped.element.update(updated_val)
                     continue
                 # else, set combobox selected value to matching in record
-                if combobox_values_only:
-                    val = mapped.element.widget.current()
-                    updated_val = combobox_values[val]
+                if combo_values_only:
+                    val = mapped.element.get().get_pk()
+                    for entry in combobox_values:
+                        if entry.get_pk() == val:
+                            updated_val = entry.get_val()
+                            break
                     mapped.element.update(values=combobox_values)
                 else:
                     mapped.element.update(values=combobox_values)


### PR DESCRIPTION
If the description_column has changed, or a new record inserted, we want to make sure to update other elements that may depend on it, that otherwise wouldn't be requeried because they are not setup as on_update_cascade.

**Updates**
- _get_description_for_pk so that it doesn't show unsaved changes to another table

**Relationship.get_dependent_columns**
Returns a dictionary of the `DataSet.key` and column names that use the description_column text of the given parent table in their `ElementRow` objects.

**DataSet.column_in_tableheading**:
Returns True if column is in tableheading of DataSet selector(s).